### PR TITLE
Fix broken command in quick start guide

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -104,7 +104,7 @@ application.
    command:
 
 ```bash
-bash <(curl -s https://github.com/slemeur/service-binding-documentation/raw/main/static/resourecs/init-database.sh)>
+curl -sL https://github.com/slemeur/service-binding-documentation/raw/main/static/resources/init-database.sh | bash
 ```
 
 We have now finished to configured the database for the application. We are


### PR DESCRIPTION
The `bash <(curl ...)>` command in the quick start guide yields a parse error in both bash and zsh.  Instead, write it as a `curl ... | bash` snippet, which executes correctly.