### PR TITLE
quick-start: Add RBAC for SBO to read PostgreSQL operator CRs

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -56,6 +56,14 @@ The application is going to use to a PostgreSQL database backend which can be
 setup using the `v5` of [Crunchy PostgreSQL operator from OperatorHub.io][crunchy].
 We just need to make sure that the operator is availabe in our `my-postgresql` namespace.
 
+Additionally, we need to allow the Service Binding Operator to `read`, `watch` and `list` Crunchy PostgreSQL operator's
+custom resources by creating appropriate `ClusterRole` and `ClusterRoleBinding` resources. You can do it by
+running the following command:
+
+```bash
+curl -sL https://github.com/slemeur/service-binding-documentation/raw/main/static/resources/setup-pg-sbo-rbac.sh | bash
+```
+
 The installation of the operator doesn't create a database instance itself, so
 we need to create one.
 
@@ -217,7 +225,7 @@ kubectl apply -f https://github.com/slemeur/service-binding-documentation/raw/ma
 To check if the binding was successfull you can check the binding resource status conditions by the following command:
 
 ```bash
-kubectl get servicebindings spring-petclinic-rest -n my-postgresql -o jsonpath-as-json='{.status.conditions'
+kubectl get servicebindings spring-petclinic-rest -n my-postgresql -o jsonpath-as-json='{.status.conditions}'
 ```
 
 You should see output something like:

--- a/static/resources/setup-pg-sbo-rbac.sh
+++ b/static/resources/setup-pg-sbo-rbac.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+OPERATOR_NAMESPACE=$(kubectl get deploy --all-namespaces -o json | jq -r '.items[] | select(.metadata.name == "service-binding-operator").metadata.namespace')
+
+kubectl apply -f - << EOD
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: postgrescluster-reader
+rules:
+- apiGroups: ["postgres-operator.crunchydata.com"]
+  resources: ["postgresclusters"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: service-binding-operator-postgrescluster-reader
+subjects:
+- kind: ServiceAccount
+  name: service-binding-operator
+  namespace: $OPERATOR_NAMESPACE
+roleRef:
+  kind: ClusterRole
+  name: postgrescluster-reader
+  apiGroup: rbac.authorization.k8s.io
+EOD


### PR DESCRIPTION
Recently, SBO RBAC rules were adjusted by https://github.com/redhat-developer/service-binding-operator/pull/1002. That requires to define custom RBAC rules for SBO to be able to read from the PostgreSQL operator's custom resources.

This PR:
* Updates the quick-start by adding a step to setup of appropriate `ClusterRole` and `ClusterRoleBinding` for SBO to be able to `read`, `watch` and `list` PG operator's custom resources.
* Fixes a typo